### PR TITLE
Clear Compile Warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,9 +5,9 @@ defmodule Expletive.Mixfile do
     [app: :expletive,
      version: "0.1.4",
      elixir: "~> 1.0",
-     deps: deps,
-     description: description,
-     package: package,
+     deps: deps(),
+     description: description(),
+     package: package(),
      source_url: "https://github.com/xavier/expletive",
      homepage_url: "https://github.com/xavier/expletive"]
   end


### PR DESCRIPTION
With Elixir >= 1.4.0 calling functions without parentheses causes
compile warnings such as this:

```
warning: variable "package" does not exist and is being expanded
to "package()", please use parentheses to remove the ambiguity or
change the variable name
```

This removes these warnings so that projects brining in this as
a dependency don't see these warnings.