### PR TITLE
fix: fix international blacklist always returning true for Expletive.profane?

### DIFF
--- a/data/international.txt
+++ b/data/international.txt
@@ -382,7 +382,6 @@ tu puta madre
 verga
 zorra
 zorron
-
 "ass-fucker"
 asses
 assfukka

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,4 @@
-%{"earmark": {:hex, :earmark, "0.1.13"},
-  "ex_doc": {:hex, :ex_doc, "0.6.0"}}
+%{
+  "earmark": {:hex, :earmark, "0.1.13", "b6b865e874d0632998d282b1b1d0747dd8d2a83bef018cb9c3cfe1ad5e0cfa76", [:mix], [], "hexpm", "8a3c77f035cc810fe27128fb59fa303ace32c5876f059362759eb202511ceb45"},
+  "ex_doc": {:hex, :ex_doc, "0.6.0", "228cf87ac5a0c728b6b425d96a5d60b658fb1854d66746874526c771d171110b", [:mix], [], "hexpm", "a21729b6a4a35bf6e6cf770760cc26d2cecabad1f8b5b765b53d66fedec61f76"},
+}

--- a/test/blacklist_test.exs
+++ b/test/blacklist_test.exs
@@ -3,13 +3,31 @@ defmodule BlacklistTest do
 
   alias Expletive.Blacklist, as: Blacklist
 
+  @english_blacklist_config Expletive.configure(blacklist: Expletive.Blacklist.english())
+  @international_blacklist_config Expletive.configure(blacklist: Expletive.Blacklist.international())
+
   test "english blacklist" do
-    assert Enum.member?(Blacklist.english, "wrapping the weasel")
+    assert Enum.member?(Blacklist.english(), "wrapping the weasel")
   end
 
   test "international blacklist" do
-    assert Enum.member?(Blacklist.international, "shitty")
-    assert Enum.member?(Blacklist.international, "zob")
+    assert Enum.member?(Blacklist.international(), "shitty")
+    assert Enum.member?(Blacklist.international(), "zob")
   end
 
+  test "should return true if word is in the english blacklist" do
+    assert Expletive.profane?("shit", @english_blacklist_config) === true
+  end
+
+  test "should return false if word is not in the english blacklist" do
+    assert Expletive.profane?("hello", @english_blacklist_config) === false
+  end
+
+  test "should return true if word is in the international blacklist" do
+    assert Expletive.profane?("arsch", @international_blacklist_config) === true
+  end
+
+  test "should return false if word is not in the international blacklist" do
+    assert Expletive.profane?("hello", @international_blacklist_config) === false
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/xavier/expletive/issues/4