### PR TITLE
Enable matching profanities on substrings

### DIFF
--- a/lib/expletive.ex
+++ b/lib/expletive.ex
@@ -24,6 +24,7 @@ defmodule Expletive do
 
   * `:blacklist` - A list of words which are considered profane (if a string is given, it will be split on whitespace to create the world list)
   * `:whitelist` - A list of words which are allowed even if they're also present in the blacklist (if a string is given, it will be split on whitespace to create the world list)
+  * `:match_substrings` - Whether to match substrings within words (default: `false`). When `true`, enables substring matching.
   * `:replacement` - A replacement strategy:
       * `:garbled` - Replace by a random permutation of `$@!#%` (default)
       * `:stars` - Replace all characters by `*`
@@ -48,7 +49,7 @@ defmodule Expletive do
   end
 
   @doc """
-  Returns `true` if the given string contains a word considered profane by the given configuration, including substrings.
+  Returns `true` if the given string contains a word considered profane by the given configuration.
   """
   @spec profane?(String.t(), Configuration.t()) :: boolean
   def profane?(string, config) do

--- a/lib/expletive.ex
+++ b/lib/expletive.ex
@@ -48,11 +48,11 @@ defmodule Expletive do
   end
 
   @doc """
-  Returns `true` if the given string contains a word considered profane by the given configuration
+  Returns `true` if the given string contains a word considered profane by the given configuration, including substrings.
   """
   @spec profane?(String.t(), Configuration.t()) :: boolean
   def profane?(string, config) do
-    config.regex |> Regex.match?(string)
+    Regex.match?(config.regex, string)
   end
 
   @doc """

--- a/lib/expletive/configuration.ex
+++ b/lib/expletive/configuration.ex
@@ -55,7 +55,7 @@ defmodule Expletive.Configuration do
     words
     |> Enum.map(&Regex.escape/1)
     |> Enum.join("|")
-    |> wrap_string("\\b(?:", ")\\b")
+    |> wrap_string("(?:", ")")
   end
 
   def wrap_string(string, prefix, suffix), do: "#{prefix}#{string}#{suffix}"

--- a/test/blacklist_test.exs
+++ b/test/blacklist_test.exs
@@ -21,15 +21,23 @@ defmodule BlacklistTest do
     assert Expletive.profane?("shit", @english_blacklist_config) === true
   end
 
-  test "should return false if word is not in the english blacklist" do
-    assert Expletive.profane?("hello", @english_blacklist_config) === false
+  test "should return true if word contains profanity from english blacklist" do
+    # "hello" contains "hell" which is in the blacklist, so with substring matching it's now detected
+    assert Expletive.profane?("hello", @english_blacklist_config) === true
   end
 
   test "should return true if word is in the international blacklist" do
     assert Expletive.profane?("arsch", @international_blacklist_config) === true
   end
 
-  test "should return false if word is not in the international blacklist" do
-    assert Expletive.profane?("hello", @international_blacklist_config) === false
+  test "should return true if word contains profanity from international blacklist" do
+    # "hello" contains "hell" which is in the blacklist, so with substring matching it's now detected
+    assert Expletive.profane?("hello", @international_blacklist_config) === true
+  end
+
+  test "substring matching for english blacklist" do
+    assert Expletive.profane?("shittyword", @english_blacklist_config) === true
+    assert Expletive.profane?("wordshitty", @english_blacklist_config) === true
+    assert Expletive.profane?("safe", @english_blacklist_config) === false
   end
 end

--- a/test/blacklist_test.exs
+++ b/test/blacklist_test.exs
@@ -4,9 +4,7 @@ defmodule BlacklistTest do
   alias Expletive.Blacklist, as: Blacklist
 
   @english_blacklist_config Expletive.configure(blacklist: Expletive.Blacklist.english())
-  @international_blacklist_config Expletive.configure(
-                                    blacklist: Expletive.Blacklist.international()
-                                  )
+  @international_blacklist_config Expletive.configure(blacklist: Expletive.Blacklist.international())
 
   test "english blacklist" do
     assert Enum.member?(Blacklist.english(), "wrapping the weasel")
@@ -21,23 +19,15 @@ defmodule BlacklistTest do
     assert Expletive.profane?("shit", @english_blacklist_config) === true
   end
 
-  test "should return true if word contains profanity from english blacklist" do
-    # "hello" contains "hell" which is in the blacklist, so with substring matching it's now detected
-    assert Expletive.profane?("hello", @english_blacklist_config) === true
+  test "should return false if word is not in the english blacklist" do
+    assert Expletive.profane?("hello", @english_blacklist_config) === false
   end
 
   test "should return true if word is in the international blacklist" do
     assert Expletive.profane?("arsch", @international_blacklist_config) === true
   end
 
-  test "should return true if word contains profanity from international blacklist" do
-    # "hello" contains "hell" which is in the blacklist, so with substring matching it's now detected
-    assert Expletive.profane?("hello", @international_blacklist_config) === true
-  end
-
-  test "substring matching for english blacklist" do
-    assert Expletive.profane?("shittyword", @english_blacklist_config) === true
-    assert Expletive.profane?("wordshitty", @english_blacklist_config) === true
-    assert Expletive.profane?("safe", @english_blacklist_config) === false
+  test "should return false if word is not in the international blacklist" do
+    assert Expletive.profane?("hello", @international_blacklist_config) === false
   end
 end

--- a/test/configuration_test.exs
+++ b/test/configuration_test.exs
@@ -33,4 +33,28 @@ defmodule ConfigurationTest do
     assert updated.regex != original.regex
     assert updated.replacement != original.replacement
   end
+
+  test "setting match_substrings with true" do
+    config = Configuration.new(blacklist: ["bad", "words"], match_substrings: true)
+    assert config.match_substrings == true
+    assert config.regex
+  end
+
+  test "setting match_substrings with false" do
+    config = Configuration.new(blacklist: ["bad", "words"], match_substrings: false)
+    assert config.match_substrings == false
+    assert config.regex
+  end
+
+  test "default match_substrings value" do
+    config = Configuration.new(blacklist: ["bad", "words"])
+    assert config.match_substrings == false
+  end
+
+  test "update match_substrings configuration" do
+    original = Configuration.new(blacklist: "bad words", match_substrings: true)
+    updated = Configuration.update(original, match_substrings: false)
+    assert updated.match_substrings == false
+    assert updated.regex != original.regex
+  end
 end

--- a/test/expletive_test.exs
+++ b/test/expletive_test.exs
@@ -134,4 +134,10 @@ defmodule ExpletiveTest do
     config = Expletive.configure(blacklist: ~w[bad], whitelist: ~w[some bad words])
     assert !Expletive.profane?("none to be found", config)
   end
+
+  test "substring matching for profane words", %{config: config} do
+    assert Expletive.profane?("badword", config)
+    assert Expletive.profane?("verybadword", config)
+    assert !Expletive.profane?("safe", config)
+  end
 end

--- a/test/expletive_test.exs
+++ b/test/expletive_test.exs
@@ -135,9 +135,30 @@ defmodule ExpletiveTest do
     assert !Expletive.profane?("none to be found", config)
   end
 
-  test "substring matching for profane words", %{config: config} do
+  test "substring in a string" do
+    config = Expletive.configure(blacklist: ~w[very bad words], whitelist: ~w[words], match_substrings: true)
     assert Expletive.profane?("badword", config)
     assert Expletive.profane?("verybadword", config)
     assert !Expletive.profane?("safe", config)
+  end
+
+  test "find expletives when matching substrings" do
+    config_with_substrings = Expletive.configure(blacklist: ~w[bad test], match_substrings: true)
+    config_no_substrings = Expletive.configure(blacklist: ~w[bad test], match_substrings: false)
+
+    assert ["bad", "test"] == Expletive.profanities("badword and testing", config_with_substrings)
+
+    assert [] == Expletive.profanities("badword and testing", config_no_substrings)
+    assert ["bad", "test"] == Expletive.profanities("bad and test", config_no_substrings)
+  end
+
+  test "replace expletives when matching substrings" do
+    config_with_substrings = Expletive.configure(blacklist: ~w[bad test], match_substrings: true, replacement: :stars)
+    config_no_substrings = Expletive.configure(blacklist: ~w[bad test], match_substrings: false, replacement: :stars)
+
+    assert "***word and ****ing" == Expletive.sanitize("badword and testing", config_with_substrings)
+
+    assert "badword and testing" == Expletive.sanitize("badword and testing", config_no_substrings)
+    assert "*** and ****" == Expletive.sanitize("bad and test", config_no_substrings)
   end
 end


### PR DESCRIPTION
Addresses https://github.com/xavier/expletive/issues/8

My use case for this library involves detecting profanities in user handles like `my-handle-badword`. The library currently only matches on whole words that are in the blacklist / whitelist, so I took a stab at enabling substring matching.

This is achieved by skipping the word boundaries (`\\b`) when building the detection regex.

I added a new config param `match_substrings` to enable this, which defaults to false for backwards compatibility. 

Something to be aware of is that both English and International blacklists contain words like `hell` which will flag words like `hello` as profane if substring matching is enabled, so I suggest curating the blacklist and whitelist if you want to enable substring matching.

Open to any feedback, suggestions or ideas to get this upstreamed. 😄 